### PR TITLE
Better use of turbo's built-in functions, rewrite of compress()

### DIFF
--- a/src/ofxTurboJpeg.cpp
+++ b/src/ofxTurboJpeg.cpp
@@ -142,3 +142,17 @@ bool ofxTurboJpeg::load(const ofBuffer& buf, ofPixels &pix)
 	
 	return true;
 }
+
+
+int ofxTurboJpeg::getTJPixelFormat( ofImageType fmt ){
+    switch (fmt){
+        case OF_IMAGE_COLOR:
+            return TJPF_RGB;
+        case OF_IMAGE_COLOR_ALPHA:
+            return TJPF_RGBA;
+        case OF_IMAGE_GRAYSCALE:
+            return TJPF_GRAY;
+        case OF_IMAGE_UNDEFINED:
+            return TJPF_RGB;
+    }
+}

--- a/src/ofxTurboJpeg.h
+++ b/src/ofxTurboJpeg.h
@@ -13,19 +13,35 @@ public:
 	~ofxTurboJpeg();
     
     template <class T>
-    unsigned char * compress( T & img, int jpegQuality, unsigned long *size){
+    bool compress( T & img, int jpegQuality, ofBuffer & buffer){
         
         if (img.getWidth() == 0) return NULL;
         
         int pitch = 0, flags = 0, jpegsubsamp = 0;
-        *size = 0;
+        buffer.clear();
         
         unsigned int bpp = img.getPixels().getNumChannels();
+        unsigned int bytesPerLine = img.getPixels().getBytesPerPixel() *  img.getWidth();
+        unsigned char* data = (unsigned char*) malloc ( sizeof(char) *  img.getWidth() * img.getHeight() * bpp );
         
-        unsigned char * output = (unsigned char*) malloc ( sizeof(char) *  img.getWidth() * img.getHeight() * bpp );
-        tjCompress(handleCompress, img.getPixels().getData() , img.getWidth(), pitch, img.getHeight(), bpp, output, size, jpegsubsamp, jpegQuality, flags);
+        unsigned long size = 0;
         
-        return output;
+        if ( bpp == 1 ){
+            jpegsubsamp = TJSAMP_GRAY;
+        }
+        
+        int ok = tjCompress2(handleCompress, img.getPixels().getData() , img.getWidth(), bytesPerLine, img.getHeight(), getTJPixelFormat(img.getPixels().getImageType()), &data, &size, jpegsubsamp, jpegQuality, flags);
+        
+        if (ok != 0)
+        {
+            ofLogError("Error in tjCompress():")<<tjGetErrorStr();
+            free(data);
+            return false;
+        } else {
+            buffer.set(reinterpret_cast<char*>(data), size);
+            free(data);
+            return true;
+        }
     }
     
     void save( ofImage * img, string path, int jpegQuality );
@@ -64,4 +80,5 @@ private:
 	tjhandle handleDecompress;
 
     void save(ofBuffer &buf, const ofPixels& img, int jpegQuality = 90);
+    int getTJPixelFormat( ofImageType fmt );
 };

--- a/src/ofxTurboJpeg.h
+++ b/src/ofxTurboJpeg.h
@@ -22,7 +22,7 @@ public:
         
         unsigned int bpp = img.getPixels().getNumChannels();
         unsigned int bytesPerLine = img.getPixels().getBytesPerPixel() *  img.getWidth();
-        unsigned char* data = (unsigned char*) malloc ( sizeof(char) *  img.getWidth() * img.getHeight() * bpp );
+        unsigned char* data = NULL;
         
         unsigned long size = 0;
         
@@ -30,16 +30,17 @@ public:
             jpegsubsamp = TJSAMP_GRAY;
         }
         
-        int ok = tjCompress2(handleCompress, img.getPixels().getData() , img.getWidth(), bytesPerLine, img.getHeight(), getTJPixelFormat(img.getPixels().getImageType()), &data, &size, jpegsubsamp, jpegQuality, flags);
+        int ok = tjCompress2(handleCompress, img.getPixels().getData(), img.getWidth(), bytesPerLine, img.getHeight(), getTJPixelFormat(img.getPixels().getImageType()), &data, &size, jpegsubsamp, jpegQuality, flags);
         
         if (ok != 0)
         {
             ofLogError("Error in tjCompress():")<<tjGetErrorStr();
-            free(data);
+            tjFree(data);
+
             return false;
         } else {
-            buffer.set(reinterpret_cast<char*>(data), size);
-            free(data);
+            buffer.set((char*)(data), size);
+            tjFree(data);
             return true;
         }
     }


### PR DESCRIPTION
Hey Oriol,

I've been using ofxTurbo in a project to stream ws data, and realized the compress function was a) leaking memory and b) not using turbo's newer built-in functions.

Using ```tjCompress2``` allow turbo to allocate and manage memory itself–and allows for use of ```tjFree``` to release that memory. I also switched to using ofBuffer rather than a char * array and size... Because that's all built in to ofBuff, you know?

Need to look at the other functions in more detail, but getting the compress fixed was high priority for me.

-- Brett