### PR TITLE
Add xcode libjpeg linker instructions in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 Rough OF addon that uses turbo-jpeg lib to read and write jpegs. 2-4 times faster than OF's freeImge based jpeg en/decoder.
 
 You will need to install libjpeg-turbo (http://sourceforge.net/projects/libjpeg-turbo/) and its dylibs or freemImage's internal version of libjpeg will conflict with the one required by libjpeg-turbo, throwing a "Wrong JPEG library version: library is 80, caller expects 62" error. Alternatively you can just place the "libturbojpeg.dylib" by the binary and it should work. Only tested on OSX Lion.
+On Xcode you might need to change the `other linker flags` arguments' order to force linking against the ofxTurboJPEG ones first; instead of the `ImageIO.framework` ones. (simply move them up)
 
 	ofxTurboJpeg turbo;
 	


### PR DESCRIPTION
Hi,
While it compiled fine on `of_v0.12` + `macos 10.15` with Qtcreator and makefiles, I had a hard time getting it to run with Xcode; I was getting the version mismatch error stated in the readme.

It turns out that linker argument order is important for loading dylibs, and the PG puts them at the end for newly generated xcode projects. 

Forcing the embedded one by moving it to the first position resolved my issue. Readme message added.